### PR TITLE
lazy import fixes/dir injection

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,15 @@
 # Release notes
 
+## Version 0.1.1
+
+### Changed
+
+- Initialize the getter and dir functions lazily when adding lazy imports.
+
+### Fixed
+
+- Missing `__dir__` injection so `dir()` didn't show the lazy imports.
+- Error when adding lazy imports later without pre-existing lazy imports.
 
 ## Version 0.1.0
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,10 +5,11 @@
 ### Changed
 
 - Initialize the getter and dir functions lazily when adding lazy imports.
+- Guess attributes from `__all__` when `__getattr__` definition without `__dir__` function is found.
 
 ### Fixed
 
-- Missing `__dir__` injection so `dir()` didn't show the lazy imports.
+- Missing `__dir__` injection so lazy imports didn't show up in `dir()`.
 - Error when adding lazy imports later without pre-existing lazy imports.
 
 ## Version 0.1.0

--- a/docs/specials.md
+++ b/docs/specials.md
@@ -95,7 +95,6 @@ monkay.add_deprecated_lazy_import(
 )
 ```
 
-
 ## Manual extension setup
 
 Extensions can be added via the add_extension method.
@@ -127,9 +126,7 @@ with monkay.with_settings(Settings()) as new_settings:
         assert new_settings2 is None
         # settings are the old settings again
         assert monkay.settings is old_settings
-
 ```
-
 
 ## Typings
 
@@ -174,7 +171,6 @@ monkay = Monkay[Instance, Settings](
     settings_extensions_name="extensions"
 )
 ```
-
 
 ## Cages
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -47,11 +47,12 @@ When providing your own `__all__` variable **after** providing Monkay or you wan
 and update the `__all__` value via `Monkay.update_all_var` if wanted.
 
 
-
 #### Lazy imports
 
-When using lazy imports the globals get an `__getattr__` injected. A potential old `__getattr__` is used as fallback when provided **before**
-initializing the Monkay instance:
+When using lazy imports the globals get an `__getattr__` and `__dir__` injected. A potential old `__getattr__` and/or `__dir__` is used when specified **before**
+initializing the Monkay instance.
+
+The lookup hierarchy is:
 
 `module attr > monkay __getattr__ > former __getattr__ or Error`.
 
@@ -64,6 +65,17 @@ There are also `deprecated_lazy_imports` which have as value a dictionary with t
 - `reason` (Optional): Deprecation reason.
 - `new_attribute` (Optional): Upgrade path. New attribute.
 
+##### Listing all attributes with `dir()`
+
+Monkay also injects a `__dir__` module function for listing via dir. It contains all lazy imports as well as `__all__` variable contents.
+The `__dir__` function is also injected without lazy imports when an existing `__getattr__` without a `__dir__` function was detected and
+an `__all__` variable is available to fix it.
+
+In short the sources for the Monkay `__dir__` are:
+
+- Old `__dir__()` function if provided before the Monkay initialization.
+- `__all__` variable.
+- Lazy imports.
 
 ##### Caching
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -69,7 +69,8 @@ There are also `deprecated_lazy_imports` which have as value a dictionary with t
 
 Monkay also injects a `__dir__` module function for listing via dir. It contains all lazy imports as well as `__all__` variable contents.
 The `__dir__` function is also injected without lazy imports when an existing `__getattr__` without a `__dir__` function was detected and
-an `__all__` variable is available to fix it.
+an `__all__` variable is available.
+It is tried to guess the attributes provided by using the `__all__` variable.
 
 In short the sources for the Monkay `__dir__` are:
 
@@ -118,7 +119,6 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     preloads: list[str] = []
     extensions: list[Any] = []
-
 ```
 
 And voila settings are now available from monkay.settings as well as settings. This works only when all settings arguments are
@@ -189,8 +189,6 @@ monkay = Monkay(
 get_value_from_settings(monkay.settings, "foo")
 ```
 
-
-
 #### Pathes
 
 Like shown in the examples pathes end with a `:` for an attribute. But sometimes a dot is nicer.
@@ -260,9 +258,7 @@ class ExtensionProtocol(Protocol[INSTANCE, SETTINGS]):
     name: str
 
     def apply(self, monkay_instance: Monkay[INSTANCE, SETTINGS]) -> None: ...
-
 ```
-
 
 A name (can be dynamic) and the apply method are required. The instance itself is easily retrieved from
 the monkay instance.

--- a/monkay/__about__.py
+++ b/monkay/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present alex <devkral@web.de>
 #
 # SPDX-License-Identifier: BSD-3-Clauses
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/monkay/_monkay_exports.py
+++ b/monkay/_monkay_exports.py
@@ -80,7 +80,8 @@ class MonkayExports:
             ]
         ],
     ]:
-        """Debug method to check"""
+        """Debug method to check missing imports"""
+        self._init_global_getter_hook()
 
         assert self.getter is not None
         missing: dict[

--- a/tests/targets/module_none.py
+++ b/tests/targets/module_none.py
@@ -1,0 +1,5 @@
+from monkay import Monkay
+
+monkay = Monkay(
+    globals(),
+)

--- a/tests/targets/module_none_getattr.py
+++ b/tests/targets/module_none_getattr.py
@@ -1,0 +1,20 @@
+from monkay import Monkay
+
+extras = {"foo": lambda: "foo"}
+
+
+__all__ = ["foo"]  # noqa
+
+
+def __getattr__(name: str):
+    try:
+        return extras[name]
+    except KeyError as exc:
+        raise AttributeError from exc
+
+
+## __dir__ is missing
+
+monkay = Monkay(
+    globals(),
+)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -87,3 +87,51 @@ def test_add(monkay_fn, export, in_all):
     if in_all:
         assert export in mod.__all__
     assert mod.monkay.getter(export, no_warn_deprecated=True, check_globals_dict=True) is not None
+
+
+@pytest.mark.parametrize(
+    "monkay_fn,export",
+    [
+        (lambda m: m.add_lazy_import("bar", ".fn_module:bar"), "bar"),
+        (
+            lambda m: m.add_deprecated_lazy_import(
+                "deprecated",
+                {
+                    "path": "tests.targets.fn_module:deprecated",
+                    "reason": "old.",
+                    "new_attribute": "super_new",
+                },
+            ),
+            "deprecated",
+        ),
+        (
+            lambda m: m.add_lazy_import(
+                "bar2",
+                ".fn_module:bar",
+                no_hooks=True,
+            ),
+            "bar2",
+        ),
+        (
+            lambda m: m.add_deprecated_lazy_import(
+                "deprecated2",
+                {
+                    "path": "tests.targets.fn_module:deprecated",
+                    "reason": "old.",
+                    "new_attribute": "super_new",
+                },
+                no_hooks=True,
+            ),
+            "deprecated2",
+        ),
+    ],
+)
+def test_none_add(monkay_fn, export):
+    import tests.targets.module_none as mod
+
+    monkay_fn(mod.monkay)
+    mod.__all__ = mod.monkay.update_all_var([])
+    assert export in mod.__all__
+    assert (
+        mod.monkay.getter(export, no_warn_deprecated=True, check_globals_dict="fail") is not None
+    )


### PR DESCRIPTION
Changes:

- Initialize the getter and dir functions lazily when adding lazy imports.
- Bump version

Fixes:
- Missing `__dir__` injection so `dir()` didn't show the lazy imports.
- Error when adding lazy imports later without pre-existing lazy imports.