### PR TITLE
bugfixes for new evaluate_once logic

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Version 0.2.1
+
+### Fixed
+
+- Add AttributeError to the ignored import errors.
+- Wrong return value for `evaluate_settings_once` when already evaluated.
 
 ## Version 0.2.0
 

--- a/monkay/__about__.py
+++ b/monkay/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present alex <devkral@web.de>
 #
 # SPDX-License-Identifier: BSD-3-Clauses
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/monkay/core.py
+++ b/monkay/core.py
@@ -163,11 +163,11 @@ class Monkay(
         ignore_import_errors: bool = True,
     ) -> bool:
         if self.settings_evaluated:
-            return False
+            return True
         if ignore_import_errors:
             try:
                 self.evaluate_settings(on_conflict=on_conflict)
-            except ImportError:
+            except (ImportError, AttributeError):
                 return False
         else:
             self.evaluate_settings(on_conflict=on_conflict)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -54,7 +54,14 @@ def test_settings_overwrite():
         mod.monkay.evaluate_settings()
         assert mod.monkay.settings_evaluated
         # assert no evaluation anymore
-        assert not mod.monkay.evaluate_settings_once()
+        old_evaluate_settings = mod.monkay.evaluate_settings
+
+        def fake_evaluate():
+            raise
+
+        mod.monkay.evaluate_settings = fake_evaluate
+        assert mod.monkay.evaluate_settings_once()
+        mod.monkay.evaluate_settings = old_evaluate_settings
         assert "tests.targets.module_settings_preloaded" in sys.modules
 
         # overwriting settings doesn't affect temporary scope


### PR DESCRIPTION
Changes:
- fix return value when already evaluated
- also catch AttributeError as ImportError
- bump version