### PR TITLE
improved edge case handling

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,16 @@
 # Release notes
 
+## Version 0.2.2
+
+### Added
+
+- `UnsetError` for simpler checking if the settings are unset.
+
+### Fixed
+
+- Handle edge-cases better when settings are unset or disabled.
+- Don't touch settings in `evaluate_settings` when not required.
+
 ## Version 0.2.1
 
 ### Fixed

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -73,12 +73,15 @@ monkay.evaluate_settings_once()
 `evaluate_settings_once` has following keyword only parameter:
 
 - `on_conflict`: Matches the values of add_extension but defaults to `error`.
-- `ignore_import_errors`: Suppress import errors. Defaults to `True`.
+- `ignore_import_errors`: Suppress import related errors. Handles unset settings lenient. Defaults to `True`.
 
 When run successfully the context-aware flag `settings_evaluated` is set. If the flag is set,
 the method becomes a noop until the flag is lifted by assigning new settings.
 
 The return_value is `True` for a successful evaluation and `False` in the other case.
+
+!!! Note
+    `ignore_import_errors` suppresses also UnsetError which is raised when the settings are unset.
 
 ### `evaluate_settings` method
 
@@ -90,10 +93,14 @@ It has has following keyword only parameter:
 
 It is internally used by `evaluate_settings_once` and will also set the `settings_evaluated` flag.
 
+!!! Note
+    `evaluate_settings` doesn't touch the settings when no `settings_preloads_name` and/or `settings_extensions_name` is set
+    but will still set the `settings_evaluated` flag to `True`.
+
 ### `settings_evaluated` flag
 
 Internally it is a property which sets the right flag. Either on the ContextVar or on the instance.
-It is resetted when assigning settings and initial False for `with_settings`.
+It is resetted when assigning settings and initial `False` for `with_settings`.
 
 ## Other settings types
 
@@ -125,8 +132,11 @@ class SettingsForward:
 settings = cast("EdgySettings", SettingsForward())
 
 __all__ = ["settings"]
-
 ```
+
+!!! Note
+    For enabling settings modifications, you may need to define `__setattr__`, `__delattr__` too.
+    It is however not recommended.
 
 ## Deleting settings
 

--- a/monkay/__about__.py
+++ b/monkay/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present alex <devkral@web.de>
 #
 # SPDX-License-Identifier: BSD-3-Clauses
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/monkay/__init__.py
+++ b/monkay/__init__.py
@@ -4,6 +4,7 @@
 
 from .base import (
     InGlobalsDict,
+    UnsetError,
     absolutify_import,
     get_value_from_settings,
     load,
@@ -29,6 +30,7 @@ __all__ = [
     "load_any",
     "absolutify_import",
     "InGlobalsDict",
+    "UnsetError",
     "get_value_from_settings",
     "Cage",
     "TransparentCage",

--- a/monkay/_monkay_settings.py
+++ b/monkay/_monkay_settings.py
@@ -7,7 +7,7 @@ from functools import cached_property
 from inspect import isclass
 from typing import Generic, cast
 
-from .base import load
+from .base import UnsetError, load
 from .types import SETTINGS
 
 
@@ -70,9 +70,7 @@ class MonkaySettings(Generic[SETTINGS]):
         if callable(settings):
             settings = settings()
         if settings is None:
-            raise RuntimeError(
-                "Settings are not set yet. Returned settings are None or settings_path is empty."
-            )
+            raise UnsetError("Settings are not set yet or the settings function returned None.")
         return settings
 
     @settings.setter

--- a/monkay/base.py
+++ b/monkay/base.py
@@ -59,8 +59,10 @@ def absolutify_import(import_path: str, package: str | None) -> str:
     return f"{package}.{import_path.lstrip('.')}"
 
 
-class InGlobalsDict(Exception):
-    pass
+class InGlobalsDict(Exception): ...
+
+
+class UnsetError(RuntimeError): ...
 
 
 def get_value_from_settings(settings: Any, name: str) -> Any:

--- a/tests/targets/module_disabled_settings.py
+++ b/tests/targets/module_disabled_settings.py
@@ -1,0 +1,36 @@
+from monkay import Monkay
+
+extras = {"foo": lambda: "foo"}
+
+
+def __getattr__(name: str):
+    try:
+        return extras[name]
+    except KeyError as exc:
+        raise AttributeError from exc
+
+
+class FakeApp:
+    is_fake_app: bool = True
+
+
+__all__ = ["foo", "stringify_all"]  # noqa
+monkay = Monkay(
+    globals(),
+    with_extensions=True,
+    with_instance=True,
+    settings_path=False,
+    lazy_imports={
+        "bar": ".fn_module:bar",
+        "bar2": "..targets.fn_module:bar2",
+        "dynamic": lambda: "dynamic",
+        "settings": lambda: monkay.settings,
+    },
+    deprecated_lazy_imports={
+        "deprecated": {
+            "path": "tests.targets.fn_module:deprecated",
+            "reason": "old.",
+            "new_attribute": "super_new",
+        }
+    },
+)

--- a/tests/targets/module_disabled_settings.py
+++ b/tests/targets/module_disabled_settings.py
@@ -14,7 +14,7 @@ class FakeApp:
     is_fake_app: bool = True
 
 
-__all__ = ["foo", "stringify_all"]  # noqa
+__all__ = ["foo"]  # noqa
 monkay = Monkay(
     globals(),
     with_extensions=True,

--- a/tests/targets/module_notevaluated_settings.py
+++ b/tests/targets/module_notevaluated_settings.py
@@ -1,0 +1,23 @@
+from monkay import Monkay
+
+extras = {"foo": lambda: "foo"}
+
+
+def __getattr__(name: str):
+    try:
+        return extras[name]
+    except KeyError as exc:
+        raise AttributeError from exc
+
+
+class FakeApp:
+    is_fake_app: bool = True
+
+
+__all__ = ["foo"]  # noqa
+monkay = Monkay(
+    globals(),
+    with_extensions=True,
+    with_instance=True,
+    settings_path="tests.targets.not_existing_settings_path:Settings",
+)

--- a/tests/targets/module_notfound_settings.py
+++ b/tests/targets/module_notfound_settings.py
@@ -1,0 +1,25 @@
+from monkay import Monkay
+
+extras = {"foo": lambda: "foo"}
+
+
+def __getattr__(name: str):
+    try:
+        return extras[name]
+    except KeyError as exc:
+        raise AttributeError from exc
+
+
+class FakeApp:
+    is_fake_app: bool = True
+
+
+__all__ = ["foo"]  # noqa
+monkay = Monkay(
+    globals(),
+    with_extensions=True,
+    with_instance=True,
+    settings_path="tests.targets.not_existing_settings_path:Settings",
+    settings_preloads_name="preloads",
+    settings_extensions_name="extensions",
+)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -44,6 +44,31 @@ def test_disabled_settings():
         mod.monkay.settings  # noqa
 
 
+def test_notfound_settings():
+    import tests.targets.module_notfound_settings as mod
+
+    assert not mod.monkay.settings_evaluated
+
+    mod.monkay.evaluate_settings_once()
+    assert not mod.monkay.settings_evaluated
+
+    with pytest.raises(ImportError):
+        mod.monkay.evaluate_settings_once(ignore_import_errors=False)
+
+
+def test_notevaluated_settings():
+    import tests.targets.module_notevaluated_settings as mod
+
+    assert mod.monkay.settings_evaluated
+
+    mod.monkay.evaluate_settings_once()
+    mod.monkay.evaluate_settings_once(ignore_import_errors=False)
+
+    # now evaluate settings
+    with pytest.raises(ImportError):
+        mod.monkay.settings  # noqa
+
+
 @pytest.mark.parametrize("value", [False, None, ""])
 def test_unset_settings(value):
     import tests.targets.module_full as mod

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from monkay import UnsetError
+
 
 @pytest.fixture(autouse=True, scope="function")
 def cleanup():
@@ -30,6 +32,30 @@ def test_settings_basic():
     mod.monkay.settings = Settings
     mod.monkay.settings = "tests.targets.settings:hurray"
     assert mod.monkay.settings is hurray
+
+
+def test_disabled_settings():
+    import tests.targets.module_disabled_settings as mod
+
+    with pytest.raises(AssertionError):
+        mod.monkay.evaluate_settings_once()
+
+    with pytest.raises(AssertionError):
+        mod.monkay.settings  # noqa
+
+
+@pytest.mark.parametrize("value", [False, None, ""])
+def test_unset_settings(value):
+    import tests.targets.module_full as mod
+
+    mod.monkay.settings = value
+
+    mod.monkay.evaluate_settings_once()
+    with pytest.raises(UnsetError):
+        mod.monkay.evaluate_settings_once(ignore_import_errors=False)
+
+    with pytest.raises(UnsetError):
+        mod.monkay.settings  # noqa
 
 
 def test_settings_overwrite():


### PR DESCRIPTION
During the integration in edgy some edge cases were found which are now handled better. It affects only cases where settings are disabled or unset or the evaluated names are unset.

Changes:

- handle unset settings more lenient
- don't access settings when there is no reason to do so
- add UnsetError