### PR TITLE
emergency release 0.3.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,12 +6,18 @@
 
 This is an emergency release. It removes the feature that implicitly evaluates settings during `__init__`. This
 is very error prone and can lead to two different versions of the same library in case the sys.path is manipulated.
+Also failed imports are not neccessarily side-effect free.
+
+### Added
+
+- `evaluate_settings` has now two extra keyword parameters: `onetime` and `ignore_preload_import_errors`.
 
 ### Changes
 
-- `evaluate_settings` behaves like `evaluate_settings_once`. We will need this too often now and having two versions is error-prone.
-- `evaluate_settings_once` is deprecated.
+- `evaluate_settings` behaves like `evaluate_settings_once`. We will need this too often now and having two similar named versions is error-prone.
+- `evaluate_settings_once` is now deprecated.
 - Setting the `evaluate_settings` parameter in `__init__` is now an error.
+- For the parameter `ignore_import_errors` of `evaluate_settings` the default value is changed to `False`.
 
 ## Version 0.2.2
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,18 @@
 # Release notes
 
+## Version 0.3.0
+
+### Breaking
+
+This is an emergency release. It removes the feature that implicitly evaluates settings during `__init__`. This
+is very error prone and can lead to two different versions of the same library in case the sys.path is manipulated.
+
+### Changes
+
+- `evaluate_settings` behaves like `evaluate_settings_once`. We will need this too often now and having two versions is error-prone.
+- `evaluate_settings_once` is deprecated.
+- Setting the `evaluate_settings` parameter in `__init__` is now an error.
+
 ## Version 0.2.2
 
 ### Added

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -64,6 +64,26 @@ else:
 monkay.evaluate_settings()
 ```
 
+## Multi stage settings setup
+
+By passing `ignore_import_errors=True` we can check multiple pathes if the config could load. We get a False as return value in case of not.
+
+``` python
+import os
+from monkay import Monkay
+
+monkay = Monkay(
+    globals(),
+    # required for initializing settings feature
+    settings_path=""
+)
+
+def find_settings():
+    for path in ["a.settings", "b.settings.develop"]:
+        if monkay.evaluate_settings(ignore_import_errors=True):
+            break
+```
+
 ### `evaluate_settings` method
 
 There is also`evaluate_settings` which evaluates always, not checking for if the settings were
@@ -73,8 +93,8 @@ It has has following keyword only parameter:
 
 - `on_conflict`: Matches the values of add_extension but defaults to `error`.
 - `onetime`: Evaluates the settings only one the first call. All other calls become noops. Defaults to `True`.
-- `ignore_import_errors`: Suppress import related errors. Handles unset settings lenient. Defaults to `True`.
-
+- `ignore_import_errors`: Suppress import related errors concerning settings. Handles unset settings lenient. Defaults to `False`.
+- `ignore_preload_import_errors`: Suppress import related errors concerning preloads in settings. Defaults to `True`.
 
 !!! Note
     `evaluate_settings` doesn't touch the settings when no `settings_preloads_name` and/or `settings_extensions_name` is set

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -38,10 +38,7 @@ child.monkay.settings = lambda: monkay.settings
 
 ## Lazy settings setup
 
-Like when using a settings forward it is possible to activate the settings later by assigning a string, a class or an settings instance
-to the settings attribute.
-For this provide an empty string to the settings_path variable.
-It ensures the initialization takes place.
+Settings are only evaluated when calling `evaluate_settings`. This means you can do a lazy setup like this:
 
 ``` python
 import os
@@ -49,9 +46,8 @@ from monkay import Monkay
 
 monkay = Monkay(
     globals(),
-    # required for initializing settings
+    # required for initializing settings feature
     settings_path=""
-    evaluate_settings=False
 )
 
 # somewhere later
@@ -65,37 +61,27 @@ else:
     monkay.settings = DebugSettings()
 
 # now the settings are applied
-monkay.evaluate_settings_once()
+monkay.evaluate_settings()
 ```
-
-### `evaluate_settings_once` method
-
-`evaluate_settings_once` has following keyword only parameter:
-
-- `on_conflict`: Matches the values of add_extension but defaults to `error`.
-- `ignore_import_errors`: Suppress import related errors. Handles unset settings lenient. Defaults to `True`.
-
-When run successfully the context-aware flag `settings_evaluated` is set. If the flag is set,
-the method becomes a noop until the flag is lifted by assigning new settings.
-
-The return_value is `True` for a successful evaluation and `False` in the other case.
-
-!!! Note
-    `ignore_import_errors` suppresses also UnsetError which is raised when the settings are unset.
 
 ### `evaluate_settings` method
 
 There is also`evaluate_settings` which evaluates always, not checking for if the settings were
 evaluated already and not optionally ignoring import errors.
+The return_value is `True` for a successful evaluation and `False` in the other case.
 It has has following keyword only parameter:
 
-- `on_conflict`: Matches the values of add_extension but defaults to `keep`.
+- `on_conflict`: Matches the values of add_extension but defaults to `error`.
+- `onetime`: Evaluates the settings only one the first call. All other calls become noops. Defaults to `True`.
+- `ignore_import_errors`: Suppress import related errors. Handles unset settings lenient. Defaults to `True`.
 
-It is internally used by `evaluate_settings_once` and will also set the `settings_evaluated` flag.
 
 !!! Note
     `evaluate_settings` doesn't touch the settings when no `settings_preloads_name` and/or `settings_extensions_name` is set
     but will still set the `settings_evaluated` flag to `True`.
+
+!!! Note
+    `ignore_import_errors` suppresses also UnsetError which is raised when the settings are unset.
 
 ### `settings_evaluated` flag
 

--- a/docs/specials.md
+++ b/docs/specials.md
@@ -130,7 +130,8 @@ with monkay.with_settings(Settings()) as new_settings:
 
 ## `evaluate_preloads`
 
-`evaluate_preloads` is a way to load preloads everywhere in the application.
+`evaluate_preloads` is a way to load preloads everywhere in the application. It returns True if all preloads succeeded.
+This is useful together with `ignore_import_errors=True`.
 
 ### Parameters
 
@@ -139,7 +140,7 @@ with monkay.with_settings(Settings()) as new_settings:
   strings must be available. When `False` all must be available.
 - `package` (Optional). Provide a different package as parent package. By default (when empty) the package of the Monkay instance is used.
 
-Note: `monkay.base` contains a slightly different `evaluate_preloads` which uses when no package is provided the None package. It doesn't require
+Note: `monkay.base` contains a slightly different `evaluate_preloads` which uses when no package is provided the `None` package. It doesn't require
 an Monkay instance either.
 
 ## Typings
@@ -152,7 +153,6 @@ Monkay features also a protocol type for extensions: `ExtensionProtocol`.
 This is protocol is runtime checkable and has also support for both paramers.
 
 Here a combined example:
-
 
 ```python
 from dataclasses import dataclass

--- a/docs/specials.md
+++ b/docs/specials.md
@@ -128,6 +128,20 @@ with monkay.with_settings(Settings()) as new_settings:
         assert monkay.settings is old_settings
 ```
 
+## `evaluate_preloads`
+
+`evaluate_preloads` is a way to load preloads everywhere in the application.
+
+### Parameters
+
+- `preloads` (also positional): import strings to import. See [Preloads](./tutorial.md#preloads) for the special syntax.
+- `ignore_import_errors`: Ignore import errors of preloads. When `True` (default) not all import
+  strings must be available. When `False` all must be available.
+- `package` (Optional). Provide a different package as parent package. By default (when empty) the package of the Monkay instance is used.
+
+Note: `monkay.base` contains a slightly different `evaluate_preloads` which uses when no package is provided the None package. It doesn't require
+an Monkay instance either.
+
 ## Typings
 
 Monkay is fully typed and its main class Monkay is a Generic supporting 2 type parameters:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,9 +10,9 @@ pip install monkay
 
 ### Usage
 
-Probably in the main `__init__.py` you define something like this:
+Probably you define something like this:
 
-``` python
+``` python title="foo/__init__.py"
 from monkay import Monkay
 
 monkay = Monkay(
@@ -38,6 +38,15 @@ monkay = Monkay(
         }
     },
 )
+```
+
+``` python title="foo/main.py"
+from foo import monkay
+def get_application():
+    # sys.path updates
+    monkay.evaluate_settings(prelo)
+
+
 ```
 
 When providing your own `__all__` variable **after** providing Monkay or you want more controll, you can provide
@@ -131,10 +140,11 @@ class Settings(BaseSettings):
 
 def get_application():
     # initialize the loaders/sys.path
+    # add additional preloads
+    monkay.evaluate_preloads(...)
     monkay.evaluate_settings()
 
 app = get_application()
-
 ```
 
 And voila settings are now available from monkay.settings as well as settings. This works only when all settings arguments are
@@ -286,8 +296,10 @@ class Settings(BaseSettings):
     preloads: list[str] = ["preloader:preloader"]
 ```
 
-!!! Note
-    Settings preloads are only executed after executing `evaluate_settings()`. Preloads given in the `__init__` instantly.
+!!! Warning
+    Settings preloads are only executed after executing `evaluate_settings()`. Preloads given in the `__init__` are evaluated instantly.
+    You can however call `evaluate_preloads` directly.
+
 
 #### Using the instance feature
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -44,12 +44,14 @@ monkay = Monkay(
 from foo import monkay
 def get_application():
     # sys.path updates
-    monkay.evaluate_settings(prelo)
-
-
+    important_preloads =[...]
+    monkay.evaluate_preloads(important_preloads, ignore_import_errors=False)
+    extra_preloads =[...]
+    monkay.evaluate_preloads(extra_preloads)
+    monkay.evaluate_settings()
 ```
 
-When providing your own `__all__` variable **after** providing Monkay or you want more controll, you can provide
+When providing your own `__all__` variable **after** providing Monkay or you want more control, you can provide
 
 `skip_all_update=True`
 
@@ -232,7 +234,7 @@ from functools import lru_cache
 @lru_cache
 def get_edgy():
     import edgy
-    edgy.monkay.evaluate_settings()
+    edgy.monkay.evaluate_settings(ignore_import_errors=False)
     return edgy
 
 class SettingsForward:
@@ -254,10 +256,6 @@ def get_application():
 
 app = get_application()
 ```
-
-For performance reasons you may want to skip to try to import the settings in init:
-
-`evaluate_settings=False` will disable the evaluation.
 
 You may want to not silence the import error like in monkay `<0.2.0`, then pass
 
@@ -308,7 +306,6 @@ parameter.
 
 For entrypoints you can set now the instance via `set_instance`. A good entrypoint is the init and using the settings:
 
-
 ``` python title="__init__.py"
 import os
 from monkay import Monkay, load
@@ -324,7 +321,6 @@ monkay = Monkay(
 
 monkay.evaluate_settings()
 monkay.set_instance(load(settings.APP_PATH))
-
 ```
 
 #### Using the extensions feature

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -49,8 +49,7 @@ and update the `__all__` value via `Monkay.update_all_var` if wanted.
 !!! Warning
     There is a catch when using `settings_preloads_name` and/or `settings_preloads_name`.
     It is easy to run in circular dependency errors.
-    For fixing the initialization the errors are by default catched and ignored.
-    But this means, you have to apply them later via `evaluate_settings_once` later.
+    But this means, you have to apply them later via `evaluate_settings` later.
     For more informations see [Settings preloads and/or extensions](#settings-extensions-andor-preloads)
 
 
@@ -128,6 +127,16 @@ class Settings(BaseSettings):
     extensions: list[Any] = []
 ```
 
+``` python title="main.py"
+
+def get_application():
+    # initialize the loaders/sys.path
+    monkay.evaluate_settings()
+
+app = get_application()
+
+```
+
 And voila settings are now available from monkay.settings as well as settings. This works only when all settings arguments are
 set via environment or defaults.
 Note the `uncached_imports`. Because temporary overwrites should be possible, we should not cache this import. The settings
@@ -197,12 +206,11 @@ get_value_from_settings(monkay.settings, "foo")
 ```
 #### Settings extensions and/or preloads
 
-When using `settings_preloads_name` and/or `settings_extensions_name` it is easy to run in circular dependency issues
-especcially with `pydantic_settings`.
-For mitigating this such import errors are catched and silenced in init.
+When using `settings_preloads_name` and/or `settings_extensions_name` we need to call in the setup of the application
+`evaluate_settings()`. Otherwise we may would end up with circular depdendencies, missing imports and wrong library versions.
 
 This means however the preloads are not loaded as well the extensions initialized.
-For initializing it later, we need `evaluate_settings_once`.
+For initializing it later, we need `evaluate_settings`.
 
 Wherever the settings are expected we can add it.
 
@@ -214,7 +222,7 @@ from functools import lru_cache
 @lru_cache
 def get_edgy():
     import edgy
-    edgy.monkay.evaluate_settings_once()
+    edgy.monkay.evaluate_settings()
     return edgy
 
 class SettingsForward:
@@ -228,7 +236,7 @@ or
 ```python title="foo/main.py"
 def get_application():
     import foo
-    foo.monkay.evaluate_settings_once(ignore_import_errors=False)
+    foo.monkay.evaluate_settings(ignore_import_errors=False)
     app = App()
 
     foo.monkay.set_instance(app)
@@ -245,7 +253,7 @@ You may want to not silence the import error like in monkay `<0.2.0`, then pass
 
 `ignore_settings_import_errors=False` to the init.
 
-More information can be found in [Settings `evaluate_settings_once`](./settings.md#evaluate_settings_once-method)
+More information can be found in [Settings `evaluate_settings`](./settings.md#evaluate_settings-method)
 
 #### Pathes
 
@@ -278,6 +286,9 @@ class Settings(BaseSettings):
     preloads: list[str] = ["preloader:preloader"]
 ```
 
+!!! Note
+    Settings preloads are only executed after executing `evaluate_settings()`. Preloads given in the `__init__` instantly.
+
 #### Using the instance feature
 
 The instance feature is activated by providing a boolean (or a string for an explicit name) to the `with_instance`
@@ -299,7 +310,9 @@ monkay = Monkay(
     settings_extensions_name="extensions",
 )
 
+monkay.evaluate_settings()
 monkay.set_instance(load(settings.APP_PATH))
+
 ```
 
 #### Using the extensions feature
@@ -340,7 +353,6 @@ class Settings(BaseSettings):
     preloads: list[str] = ["preloader:preloader"]
     extensions: list[Any] = [Extension]
     APP_PATH: str = "settings.App"
-
 ```
 
 ##### Reordering extension order dynamically
@@ -357,7 +369,6 @@ There is a second more complicated way to reorder:
 via the parameter `extension_order_key_fn`. It takes a key function which is expected to return a lexicographic key capable for ordering.
 
 You can however intermix both.
-
 
 ## Tricks
 
@@ -385,14 +396,12 @@ monkay = Monkay(
 )
 ```
 
-
 ### Static `__all__`
 
 For autocompletions it is helpful to have a static `__all__` variable because many tools parse the sourcecode.
 Handling the `__all__` manually is for small imports easy but for bigger projects problematic.
 
 Let's extend the former example:
-
 
 ``` python
 

--- a/monkay/__about__.py
+++ b/monkay/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present alex <devkral@web.de>
 #
 # SPDX-License-Identifier: BSD-3-Clauses
-__version__ = "0.2.2"
+__version__ = "0.3.0"

--- a/monkay/core.py
+++ b/monkay/core.py
@@ -13,7 +13,7 @@ from typing import (
 from ._monkay_exports import MonkayExports
 from ._monkay_instance import MonkayInstance
 from ._monkay_settings import MonkaySettings
-from .base import UnsetError, get_value_from_settings
+from .base import UnsetError, evaluate_preloads, get_value_from_settings
 from .types import (
     INSTANCE,
     PRE_ADD_LAZY_IMPORT_HOOK,
@@ -57,6 +57,7 @@ class Monkay(
         ignore_settings_import_errors: bool = True,
         pre_add_lazy_import_hook: None | PRE_ADD_LAZY_IMPORT_HOOK = None,
         post_add_lazy_import_hook: None | Callable[[str], None] = None,
+        ignore_preload_import_errors: bool = True,
         package: str | None = "",
     ) -> None:
         self.globals_dict = globals_dict
@@ -115,14 +116,7 @@ class Monkay(
             and "__dir__" not in globals_dict
         ):
             self._init_global_dir_hook()
-        for preload in preloads:
-            splitted = preload.rsplit(":", 1)
-            try:
-                module = import_module(splitted[0], self.package)
-            except ImportError:
-                module = None
-            if module is not None and len(splitted) == 2:
-                getattr(module, splitted[1])()
+        self.evaluate_preloads(preloads, ignore_import_errors=ignore_preload_import_errors)
         if evaluate_settings is not None:
             raise Exception(
                 "This feature and the evaluate_settings parameter are removed in monkay 0.3"
@@ -134,53 +128,83 @@ class Monkay(
         if import_cache:
             self._cached_imports.clear()
 
+    def evaluate_preloads(
+        self,
+        preloads: Iterable[str],
+        *,
+        ignore_import_errors: bool = True,
+        package: str | None = None,
+    ) -> bool:
+        return evaluate_preloads(
+            preloads, ignore_import_errors=ignore_import_errors, package=package or self.package
+        )
+        no_errors: bool = True
+        for preload in preloads:
+            splitted = preload.rsplit(":", 1)
+            try:
+                module = import_module(splitted[0], self.package)
+            except (ImportError, AttributeError) as exc:
+                if not ignore_import_errors:
+                    raise exc
+                no_errors = False
+                continue
+            if len(splitted) == 2:
+                getattr(module, splitted[1])()
+        return no_errors
+
     def _evaluate_settings(
         self,
         *,
-        on_conflict: Literal["error", "keep", "replace"] = "keep",
+        settings: SETTINGS,
+        on_conflict: Literal["error", "keep", "replace"],
+        ignore_preload_import_errors: bool,
+        initial_settings_evaluated: bool,
     ) -> None:
-        # don't access settings when there is nothing to evaluate
-        if not self.settings_extensions_name and not self.settings_extensions_name:
-            self.settings_evaluated = True
-            return
-
-        # load settings one time and before setting settings_evaluated to True
-        settings = self.settings
         self.settings_evaluated = True
 
-        preloads = None
-        if self.settings_preloads_name:
-            preloads = get_value_from_settings(settings, self.settings_preloads_name)
-        if preloads:
-            for preload in preloads:
-                splitted = preload.rsplit(":", 1)
-                try:
-                    module = import_module(splitted[0], self.package)
-                except ImportError:
-                    module = None
-                if module is not None and len(splitted) == 2:
-                    getattr(module, splitted[1])()
-
-        if self.settings_extensions_name:
-            for extension in get_value_from_settings(settings, self.settings_extensions_name):
-                self.add_extension(extension, use_overwrite=True, on_conflict=on_conflict)
+        try:
+            if self.settings_preloads_name:
+                settings_preloads = get_value_from_settings(settings, self.settings_preloads_name)
+                self.evaluate_preloads(
+                    settings_preloads, ignore_import_errors=ignore_preload_import_errors
+                )
+            if self.settings_extensions_name:
+                for extension in get_value_from_settings(settings, self.settings_extensions_name):
+                    self.add_extension(extension, use_overwrite=True, on_conflict=on_conflict)
+        except Exception as exc:
+            if not initial_settings_evaluated:
+                self.settings_evaluated = False
+            raise exc
 
     def evaluate_settings(
         self,
         *,
         on_conflict: Literal["error", "keep", "replace"] = "error",
-        ignore_import_errors: bool = True,
+        ignore_import_errors: bool = False,
+        ignore_preload_import_errors: bool = True,
         onetime: bool = True,
     ) -> bool:
-        if onetime and self.settings_evaluated:
+        initial_settings_evaluated = self.settings_evaluated
+        if onetime and initial_settings_evaluated:
             return True
-        if ignore_import_errors:
-            try:
-                self._evaluate_settings(on_conflict=on_conflict)
-            except (ImportError, AttributeError, UnsetError):
+        # don't access settings when there is nothing to evaluate
+        if not self.settings_extensions_name and not self.settings_extensions_name:
+            self.settings_evaluated = True
+            return
+
+        try:
+            # load settings one time and before setting settings_evaluated to True
+            settings = self.settings
+        except Exception as exc:
+            if ignore_import_errors and isinstance(exc, (UnsetError, ImportError, AttributeError)):
                 return False
-        else:
-            self._evaluate_settings(on_conflict=on_conflict)
+            raise exc
+        self._evaluate_settings(
+            on_conflict=on_conflict,
+            settings=settings,
+            ignore_preload_import_errors=ignore_preload_import_errors,
+            initial_settings_evaluated=initial_settings_evaluated,
+        )
         return True
 
     def evaluate_settings_once(

--- a/monkay/core.py
+++ b/monkay/core.py
@@ -190,7 +190,7 @@ class Monkay(
         # don't access settings when there is nothing to evaluate
         if not self.settings_extensions_name and not self.settings_extensions_name:
             self.settings_evaluated = True
-            return
+            return True
 
         try:
             # load settings one time and before setting settings_evaluated to True

--- a/tests/targets/module_full.py
+++ b/tests/targets/module_full.py
@@ -38,6 +38,7 @@ monkay = Monkay(
         }
     },
 )
+monkay.evaluate_settings()
 
 
 def stringify_all_plain(separate_by_category: bool):

--- a/tests/targets/module_notevaluated_settings.py
+++ b/tests/targets/module_notevaluated_settings.py
@@ -21,3 +21,4 @@ monkay = Monkay(
     with_instance=True,
     settings_path="tests.targets.not_existing_settings_path:Settings",
 )
+monkay.evaluate_settings()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -49,11 +49,11 @@ def test_notfound_settings():
 
     assert not mod.monkay.settings_evaluated
 
-    mod.monkay.evaluate_settings()
+    mod.monkay.evaluate_settings(ignore_import_errors=True)
     assert not mod.monkay.settings_evaluated
 
     with pytest.raises(ImportError):
-        mod.monkay.evaluate_settings(ignore_import_errors=False)
+        mod.monkay.evaluate_settings()
 
 
 def test_notevaluated_settings():
@@ -75,9 +75,9 @@ def test_unset_settings(value):
 
     mod.monkay.settings = value
 
-    mod.monkay.evaluate_settings()
+    mod.monkay.evaluate_settings(ignore_import_errors=True)
     with pytest.raises(UnsetError):
-        mod.monkay.evaluate_settings(ignore_import_errors=False)
+        mod.monkay.evaluate_settings()
 
     with pytest.raises(UnsetError):
         mod.monkay.settings  # noqa

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -38,7 +38,7 @@ def test_disabled_settings():
     import tests.targets.module_disabled_settings as mod
 
     with pytest.raises(AssertionError):
-        mod.monkay.evaluate_settings_once()
+        mod.monkay.evaluate_settings()
 
     with pytest.raises(AssertionError):
         mod.monkay.settings  # noqa
@@ -49,11 +49,11 @@ def test_notfound_settings():
 
     assert not mod.monkay.settings_evaluated
 
-    mod.monkay.evaluate_settings_once()
+    mod.monkay.evaluate_settings()
     assert not mod.monkay.settings_evaluated
 
     with pytest.raises(ImportError):
-        mod.monkay.evaluate_settings_once(ignore_import_errors=False)
+        mod.monkay.evaluate_settings(ignore_import_errors=False)
 
 
 def test_notevaluated_settings():
@@ -61,8 +61,8 @@ def test_notevaluated_settings():
 
     assert mod.monkay.settings_evaluated
 
-    mod.monkay.evaluate_settings_once()
-    mod.monkay.evaluate_settings_once(ignore_import_errors=False)
+    mod.monkay.evaluate_settings()
+    mod.monkay.evaluate_settings(ignore_import_errors=False)
 
     # now evaluate settings
     with pytest.raises(ImportError):
@@ -75,9 +75,9 @@ def test_unset_settings(value):
 
     mod.monkay.settings = value
 
-    mod.monkay.evaluate_settings_once()
+    mod.monkay.evaluate_settings()
     with pytest.raises(UnsetError):
-        mod.monkay.evaluate_settings_once(ignore_import_errors=False)
+        mod.monkay.evaluate_settings(ignore_import_errors=False)
 
     with pytest.raises(UnsetError):
         mod.monkay.settings  # noqa
@@ -102,17 +102,17 @@ def test_settings_overwrite():
         assert mod.monkay.settings is yielded
         assert mod.monkay.settings is not old_settings
         assert "tests.targets.module_settings_preloaded" not in sys.modules
-        mod.monkay.evaluate_settings()
+        mod.monkay.evaluate_settings(onetime=False, on_conflict="keep")
         assert mod.monkay.settings_evaluated
         # assert no evaluation anymore
-        old_evaluate_settings = mod.monkay.evaluate_settings
+        old_evaluate_settings = mod.monkay._evaluate_settings
 
         def fake_evaluate():
             raise
 
-        mod.monkay.evaluate_settings = fake_evaluate
-        assert mod.monkay.evaluate_settings_once()
-        mod.monkay.evaluate_settings = old_evaluate_settings
+        mod.monkay._evaluate_settings = fake_evaluate
+        assert mod.monkay.evaluate_settings()
+        mod.monkay._evaluate_settings = old_evaluate_settings
         assert "tests.targets.module_settings_preloaded" in sys.modules
 
         # overwriting settings doesn't affect temporary scope
@@ -140,9 +140,9 @@ def test_settings_overwrite_evaluate_modes(mode, transform):
         assert new_settings is not None
         if mode == "error":
             with pytest.raises(KeyError):
-                mod.monkay.evaluate_settings(on_conflict=mode)
+                mod.monkay.evaluate_settings(on_conflict=mode, onetime=False)
         else:
-            mod.monkay.evaluate_settings(on_conflict=mode)
+            mod.monkay.evaluate_settings(on_conflict=mode, onetime=False)
 
 
 @pytest.mark.parametrize("transform", [lambda x: x, lambda x: x.model_dump()])
@@ -160,4 +160,4 @@ def test_settings_overwrite_evaluate_no_conflict(transform):
         )
     ) as new_settings:
         assert new_settings is not None
-        mod.monkay.evaluate_settings(on_conflict="error")
+        mod.monkay.evaluate_settings(on_conflict="error", onetime=False)


### PR DESCRIPTION
My assumption about the import logic were wrong. This removes a dangerous feature (automatic settings evaluation) and

- merges `evaluate_settings_once` into `evaluate_settings`
- make preloads resilient against partial imports (attributeerrors).
- see rl notes for more